### PR TITLE
Уязвимость - заливка любого файла в фотоальбомы

### DIFF
--- a/modules/photo/controllers/photo.php
+++ b/modules/photo/controllers/photo.php
@@ -523,7 +523,10 @@ class Photo_Controller extends Controller
                             $file['filesize'] = filesize($_FILES['file_upload']['tmp_name']);
 
                             if (!strstr($_FILES['file_upload']['type'], 'image/'))
+                                $this->error .= 'Неверный формат фотографии! Разрешены только gif, jpg и png<br />';				
+		            elseif ($file['file_ext'] != 'jpg' && $file['file_ext'] != 'jpeg' && $file['file_ext'] != 'gif' && $file['file_ext'] != 'png')
                                 $this->error .= 'Неверный формат фотографии! Разрешены только gif, jpg и png<br />';
+				
                         } else if (!empty($_POST['file_import']) && $_POST['file_import'] != 'http://') {
                             $type = 'import';
                             $file['real_name'] = main::detranslite(basename($_POST['file_import']));


### PR DESCRIPTION
Проверки $_FILES...['type'] на image/* недостаточно, так как это значение можно подделать.
Залитый .php файл как демонстрация https://mobilecms.pro/files/photo/27.php
Хорошо что исполнение php отключено для папки /files/, но уязвимость лучше пофиксить.